### PR TITLE
Add check for logged in user

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,8 +1,0 @@
-# All files
-[*]
-end_of_line = LF
-indent_style = space
-indent_size = 4
-charset = utf-8
-trim_trailing_whitespace = true
-insert_final_newline = true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,114 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  code-style:
+    name:    Code style check
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: PHP-CS-Fixer
+        uses: docker://oskarstark/php-cs-fixer-ga
+        with:
+          args: --rules=@PSR2 --dry-run -v .
+  tests:
+    name:    Unit tests
+    needs:   code-style
+    runs-on: ubuntu-18.04
+    env:
+      MYSQL_ROOT_PASSWORD: password
+      MYSQL_DATABASE:      drupal
+      APACHE_DIR:          "/etc/apache2"
+      SITE_NAME:           "composer-site.com"
+      LOCAL_DEPLOY_TARGET: "/var/www/html"
+      EXTENSION_NAME:      "api-subscription"
+      PHP_VERSION:         7.3
+    services:
+      mysql:
+        image:   mysql:5.7
+        env:
+          MYSQL_ROOT_PASSWORD:        ${{ env.MYSQL_ROOT_PASSWORD }}
+          MYSQL_ALLOW_EMPTY_PASSWORD: yes
+          MYSQL_DATABASE:             ${{ env.MYSQL_DATABASE }}
+        ports:
+          - 3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+    steps:
+      - name: Setup PHP and the extensions also the tools
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ env.PHP_VERSION }}
+          tools:       composer:v1, phpunit:8.5.0
+          extensions:  cli fpm mysql json opcache mbstring xml gd curl intl xdebug
+          coverage:    xdebug
+
+      - name: Start mysql daemon.
+        run:  |
+              sudo systemctl start mysql
+
+      - name: Install CV command
+        run:  |
+              curl -LsS https://download.civicrm.org/cv/cv.phar -o cv
+              sudo mv cv /usr/local/bin/
+              sudo chmod +x /usr/local/bin/cv
+
+      - name: Basic apache module and config
+        run:  |
+              sudo apt-get update
+              sudo apt-get install libapache2-mod-php7.3
+              sudo a2enmod rewrite
+
+      - name: Get DSG application.
+        uses: actions/checkout@v2
+        with:
+          repository: akosgarai/dsg
+          path:       dsg
+
+      - name: Build drupal site with civicrm.
+        env:
+          PROJECT_BASE_PATH:   "."
+          SITE_NAME:           ${{ env.SITE_NAME }}
+          DB_NAME:             ${{ env.MYSQL_DATABASE }}
+          DB_HOST:             "127.0.0.1"
+          DB_PORT:             ${{ job.services.mysql.ports['3306'] }}
+          DB_USER:             "root@localhost"
+          MYSQL_DB_PASS:       ${{ env.MYSQL_ROOT_PASSWORD }}
+          SITE_ADMIN_NAME:     "admin"
+          SITE_ADMIN_PW:       "jPoLvGGGV5"
+          APACHE_CONF_DIR:     ${{ env.APACHE_DIR }}
+          LOCAL_DEPLOY_TARGET: ${{ env.LOCAL_DEPLOY_TARGET }}
+          COMPOSER_APP:        composer
+        run:  |
+              sudo mv dsg/apache2.conf ${{ env.APACHE_DIR }}/apache2.conf
+              ./dsg/scripts.sh ci-build --project-base-path "${PROJECT_BASE_PATH}" --project-name "${SITE_NAME}" --db-name "${DB_NAME}" --db-user-name "${DB_USER}" --site-admin-user-name "${SITE_ADMIN_NAME}" --site-admin-password "${SITE_ADMIN_PW}" --apache-conf-dir "${APACHE_CONF_DIR}" --db-host "${DB_HOST}" --db-port "${DB_PORT}" --root-db-user-pw "${MYSQL_DB_PASS}" --local-deploy-target "${LOCAL_DEPLOY_TARGET}" -s --composer-app "${COMPOSER_APP}"
+
+      - name: Get rc-base as it is required for this.
+        uses: actions/checkout@v2
+        with:
+          repository: reflexive-communications/rc-base
+          path:       rc-base
+
+      - name: Move rc-base to the extensions directory and enable the extension.
+        run:  |
+              sudo mv rc-base ${{ env.LOCAL_DEPLOY_TARGET }}"/"${{ env.SITE_NAME }}"/web/sites/default/files/civicrm/ext"
+              cd ${{ env.LOCAL_DEPLOY_TARGET }}"/"${{ env.SITE_NAME }}
+              cv --no-interaction --cwd=${{ env.LOCAL_DEPLOY_TARGET }}/${{ env.SITE_NAME }} ext:enable rc-base
+
+      - name: Check out the code
+        uses: actions/checkout@v2
+        with:
+          path: ${{ env.EXTENSION_NAME }}
+
+      - name: Move code under extensions directory and enable the extension.
+        run:  |
+              sudo mv ${{ env.EXTENSION_NAME }} ${{ env.LOCAL_DEPLOY_TARGET }}"/"${{ env.SITE_NAME }}"/web/sites/default/files/civicrm/ext"
+              cd ${{ env.LOCAL_DEPLOY_TARGET }}"/"${{ env.SITE_NAME }}
+              cv --no-interaction --cwd=${{ env.LOCAL_DEPLOY_TARGET }}/${{ env.SITE_NAME }} ext:enable ${{ env.EXTENSION_NAME }}
+
+      - name: Run unit tests
+        run:  |
+              cd ${{ env.LOCAL_DEPLOY_TARGET }}"/"${{ env.SITE_NAME }}"/web/sites/default/files/civicrm/ext/"${{ env.EXTENSION_NAME }}
+              XDEBUG_MODE=coverage XDEBUG_MODE_COVERAGE=coverage phpunit --verbose --coverage-text

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,15 @@ on:
   pull_request:
     branches: [ main ]
 
+env:
+  MYSQL_ROOT_PASSWORD: password
+  MYSQL_DATABASE:      drupal
+  APACHE_DIR:          "/etc/apache2"
+  SITE_NAME:           "composer-site.com"
+  LOCAL_DEPLOY_TARGET: "/var/www/html"
+  EXTENSION_NAME:      "auto-parent-tag"
+  PHP_VERSION:         7.3
+
 jobs:
   code-style:
     name:    Code style check
@@ -18,14 +27,6 @@ jobs:
     name:    Unit tests
     needs:   code-style
     runs-on: ubuntu-18.04
-    env:
-      MYSQL_ROOT_PASSWORD: password
-      MYSQL_DATABASE:      drupal
-      APACHE_DIR:          "/etc/apache2"
-      SITE_NAME:           "composer-site.com"
-      LOCAL_DEPLOY_TARGET: "/var/www/html"
-      EXTENSION_NAME:      "api-subscription"
-      PHP_VERSION:         7.3
     services:
       mysql:
         image:   mysql:5.7

--- a/README.md
+++ b/README.md
@@ -1,35 +1,28 @@
 # auto-parent-tag
 
-If a child tag is added to a contact, the parent tag will be added automatically.
-This is done recursively until a top-tag is reached. (No more parents)
+![CI](https://github.com/reflexive-communications/auto-parent-tag/workflows/CI/badge.svg)
+
+If a child tag is added to a contact, the parent tag will be added automatically. This is done recursively until a
+top-tag is reached. (No more parents)
 
 The extension is licensed under [AGPL-3.0](LICENSE.txt).
 
 ## Requirements
 
-* PHP v7.2+
+* PHP v7.3+
 * CiviCRM (5.25) probably work below, not tested
+* [RC-Base](https://github.com/reflexive-communications/rc-base) v0.7.0+
 
-## Installation (CLI, Zip)
+## Installation
 
-Sysadmins and developers may download the `.zip` file for this extension and
-install it with the command-line tool [cv](https://github.com/civicrm/cv).
-
-```bash
-cd <extension-dir>
-cv dl auto-parent-tag@https://gitlab.com/semsey_sandor_civicrm/extensions/auto-parent-tag/-/archive/master/auto-parent-tag-master.zip
-```
-
-## Installation (CLI, Git)
-
-Sysadmins and developers may clone the [Git](https://en.wikipedia.org/wiki/Git) repo for this extension and
-install it with the command-line tool [cv](https://github.com/civicrm/cv).
+Sysadmins and developers may clone the [Git](https://en.wikipedia.org/wiki/Git) repo for this extension and install it
+with the command-line tool [cv](https://github.com/civicrm/cv).
 
 ```bash
-git clone https://gitlab.com/semsey_sandor_civicrm/extensions/auto-parent-tag.git
+git clone https://github.com/reflexive-communications/auto-parent-tag
 cv en auto_parent_tag
 ```
 
 ## Usage
 
-When installed parent tags will be added automatically.
+When installed parent tags will be added automatically for contacts.

--- a/auto_parent_tag.php
+++ b/auto_parent_tag.php
@@ -172,7 +172,7 @@ function auto_parent_tag_civicrm_themes(&$themes)
  * @throws API_Exception
  * @throws UnauthorizedException
  */
-function auto_parent_tag_civicrm_post($op, $objectName, $objectId, &$objectRef)
+function auto_parent_tag_civicrm_postCommit($op, $objectName, $objectId, &$objectRef)
 {
     // Only when creating entity tags
     if ($objectName !== 'EntityTag' || $op !== 'create') {

--- a/auto_parent_tag.php
+++ b/auto_parent_tag.php
@@ -171,11 +171,17 @@ function auto_parent_tag_civicrm_themes(&$themes)
  *
  * @throws API_Exception
  * @throws UnauthorizedException
+ * @throws CRM_Core_Exception
  */
 function auto_parent_tag_civicrm_postCommit($op, $objectName, $objectId, &$objectRef)
 {
     // Only when creating entity tags
     if ($objectName !== 'EntityTag' || $op !== 'create') {
+        return;
+    }
+
+    // Only if tagging contacts
+    if (!is_array($objectRef) || $objectRef[1] !== 'civicrm_contact') {
         return;
     }
 
@@ -192,15 +198,6 @@ function auto_parent_tag_civicrm_postCommit($op, $objectName, $objectId, &$objec
         return;
     }
 
-    $proc = new CRM_AutoParentTag_Processor();
-
-    $parent_id = $proc->getParentTagId($objectId);
-
-    // Tag has no parent
-    if (is_null($parent_id)) {
-        return;
-    }
-
     // Add parent tag to contact
-    $proc->addTagToContact($contact_id, $parent_id);
+    CRM_AutoParentTag_Processor::addParentTag($contact_id, $objectId);
 }

--- a/auto_parent_tag.php
+++ b/auto_parent_tag.php
@@ -179,10 +179,16 @@ function auto_parent_tag_civicrm_postCommit($op, $objectName, $objectId, &$objec
         return;
     }
 
+    // Check for logged in user
+    // Don't add tag for unauthenticated user
+    if (is_null(CRM_Core_Session::getLoggedInContactID())) {
+        return;
+    }
+
     $contact_id = $objectRef[0][0];
 
     // Check for valid contact_id
-    if (!is_numeric($contact_id)) {
+    if (!CRM_Utils_Rule::positiveInteger($contact_id)) {
         return;
     }
 

--- a/info.xml
+++ b/info.xml
@@ -1,26 +1,32 @@
 <?xml version="1.0"?>
 <extension key="auto-parent-tag" type="module">
-  <file>auto_parent_tag</file>
-  <name>Auto parent tag</name>
-  <description>Automatically adds parent tag to contact if a child tag is added (recursively)</description>
-  <license>AGPL-3.0</license>
-  <maintainer>
-    <author>Sandor Semsey</author>
-    <email>sandor@es-progress.hu</email>
-  </maintainer>
-  <urls>
-    <url desc="Main Extension Page">https://gitlab.com/semsey_sandor_civicrm/extensions/auto-parent-tag</url>
-  </urls>
-  <releaseDate>2021-02-01</releaseDate>
-  <version>0.9</version>
-  <develStage>stable</develStage>
-  <compatibility>
-    <ver>5.0</ver>
-  </compatibility>
-  <classloader>
-    <psr4 prefix="Civi\" path="Civi"/>
-  </classloader>
-  <civix>
-    <namespace>CRM/AutoParentTag</namespace>
-  </civix>
+    <file>auto_parent_tag</file>
+    <name>Auto parent tag</name>
+    <description>Automatically adds parent tag to contact if a child tag is added (recursively)</description>
+    <license>AGPL-3.0</license>
+    <maintainer>
+        <author>Sandor Semsey</author>
+        <email>sandor@es-progress.hu</email>
+    </maintainer>
+    <urls>
+        <url desc="Main Extension Page">https://github.com/reflexive-communications/auto-parent-tag</url>
+        <url desc="Documentation">https://github.com/reflexive-communications/auto-parent-tag</url>
+        <url desc="Support">https://github.com/reflexive-communications/auto-parent-tag/issues</url>
+        <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
+    </urls>
+    <releaseDate>2021-04-14</releaseDate>
+    <version>0.10.0</version>
+    <develStage>beta</develStage>
+    <compatibility>
+        <ver>5.0</ver>
+    </compatibility>
+    <requires>
+        <ext>rc-base</ext>
+    </requires>
+    <classloader>
+        <psr4 prefix="Civi\" path="Civi"/>
+    </classloader>
+    <civix>
+        <namespace>CRM/AutoParentTag</namespace>
+    </civix>
 </extension>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         bootstrap="tests/phpunit/bootstrap.php"
+         testdox="true">
+    <testsuites>
+        <testsuite name="all">
+            <directory>./tests/phpunit</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory suffix=".php">./</directory>
+            <exclude>
+                <!-- Skip the test directory -->
+                <directory>./tests</directory>
+                <!-- Skip the generated files -->
+                <file>./auto_parent_tag.php</file>
+                <file>./auto_parent_tag.civix.php</file>
+            </exclude>
+        </whitelist>
+    </filter>
+    <listeners>
+        <listener class="Civi\Test\CiviTestListener">
+            <arguments/>
+        </listener>
+    </listeners>
+</phpunit>

--- a/tests/phpunit/CRM/AutoParentTag/HeadlessTestCase.php
+++ b/tests/phpunit/CRM/AutoParentTag/HeadlessTestCase.php
@@ -1,0 +1,43 @@
+<?php
+
+use Civi\Test;
+use Civi\Test\HeadlessInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Base headless Test Case
+ */
+class CRM_AutoParentTag_HeadlessTestCase extends TestCase implements HeadlessInterface
+{
+    /**
+     * Apply a forced rebuild of DB, thus
+     * create a clean DB before running tests
+     *
+     * @throws \CRM_Extension_Exception_ParseException
+     */
+    public static function setUpBeforeClass(): void
+    {
+        // Resets DB and install depended extension
+        Test::headless()
+            ->install('rc-base')
+            ->installMe(__DIR__)
+            ->apply(true);
+    }
+
+    /**
+     * The setupHeadless function runs at the start of each test case, right before
+     * the headless environment reboots.
+     *
+     * It should perform any necessary steps required for putting the database
+     * in a consistent baseline -- such as loading schema and extensions.
+     *
+     * The utility `\Civi\Test::headless()` provides a number of helper functions
+     * for managing this setup, and it includes optimizations to avoid redundant
+     * setup work.
+     *
+     * @see \Civi\Test
+     */
+    public function setUpHeadless()
+    {
+    }
+}

--- a/tests/phpunit/CRM/AutoParentTag/ProcessorHeadlessTest.php
+++ b/tests/phpunit/CRM/AutoParentTag/ProcessorHeadlessTest.php
@@ -1,0 +1,49 @@
+<?php
+
+use Civi\Test\ContactTestTrait;
+
+/**
+ * Test AutoParentTag Processor
+ *
+ * @group headless
+ */
+class CRM_AutoParentTag_ProcessorHeadlessTest extends CRM_AutoParentTag_HeadlessTestCase
+{
+    use ContactTestTrait;
+
+    /**
+     * @throws \API_Exception
+     * @throws \CRM_Core_Exception
+     */
+    public function testAddParentTag()
+    {
+        // Create tags
+        $tag = [
+            'name' => 'Parent tag',
+        ];
+        $parent_tag_id = CRM_RcBase_Test_Utils::cvApi4Create('Tag', $tag);
+        $tag = [
+            'name' => 'Child tag',
+            'parent_id' => $parent_tag_id,
+        ];
+        $child_tag_id = CRM_RcBase_Test_Utils::cvApi4Create('Tag', $tag);
+
+        // Create contact
+        $contact_id = $this->individualCreate();
+
+        // Add parent tag
+        $entity_tag_id_returned = CRM_AutoParentTag_Processor::addParentTag($contact_id, $child_tag_id);
+
+        // Check if contact actually has parent tag
+        $id = CRM_RcBase_Test_Utils::cvApi4Get('EntityTag', ['id'], [
+            'entity_table=civicrm_contact',
+            "entity_id=${contact_id}",
+            "tag_id=${parent_tag_id}",
+        ]);
+        self::assertCount(1, $id, 'Parent tag missing from contact');
+        self::assertSame($id[0]['id'], $entity_tag_id_returned, 'Bad entity tag ID returned');
+
+        // Add parent tag to parent
+        self::assertNull(CRM_AutoParentTag_Processor::addParentTag($contact_id, $parent_tag_id), 'Not null returned for parent tag');
+    }
+}

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -1,0 +1,65 @@
+<?php
+
+ini_set('memory_limit', '2G');
+ini_set('safe_mode', 0);
+// phpcs:disable
+eval(cv('php:boot --level=classloader', 'phpcode'));
+// phpcs:enable
+// Allow autoloading of PHPUnit helper classes in this extension.
+$loader = new \Composer\Autoload\ClassLoader();
+$loader->add('CRM_', __DIR__);
+$loader->add('Civi\\', __DIR__);
+$loader->add('api_', __DIR__);
+$loader->add('api\\', __DIR__);
+$loader->register();
+
+/**
+ * Call the "cv" command.
+ *
+ * @param string $cmd
+ *   The rest of the command to send.
+ * @param string $decode
+ *   Ex: 'json' or 'phpcode'.
+ *
+ * @return string
+ *   Response output (if the command executed normally).
+ * @throws \RuntimeException
+ *   If the command terminates abnormally.
+ */
+function cv($cmd, $decode = 'json')
+{
+    $cmd = 'cv '.$cmd;
+    $descriptorSpec = [0 => ["pipe", "r"], 1 => ["pipe", "w"], 2 => STDERR];
+    $oldOutput = getenv('CV_OUTPUT');
+    putenv("CV_OUTPUT=json");
+
+    // Execute `cv` in the original folder. This is a work-around for
+    // phpunit/codeception, which seem to manipulate PWD.
+    $cmd = sprintf('cd %s; %s', escapeshellarg(getenv('PWD')), $cmd);
+
+    $process = proc_open($cmd, $descriptorSpec, $pipes, __DIR__);
+    putenv("CV_OUTPUT=$oldOutput");
+    fclose($pipes[0]);
+    $result = stream_get_contents($pipes[1]);
+    fclose($pipes[1]);
+    if (proc_close($process) !== 0) {
+        throw new RuntimeException("Command failed ($cmd):\n$result");
+    }
+    switch ($decode) {
+        case 'raw':
+            return $result;
+
+        case 'phpcode':
+            // If the last output is /*PHPCODE*/, then we managed to complete execution.
+            if (substr(trim($result), 0, 12) !== "/*BEGINPHP*/" || substr(trim($result), -10) !== "/*ENDPHP*/") {
+                throw new \RuntimeException("Command failed ($cmd):\n$result");
+            }
+            return $result;
+
+        case 'json':
+            return json_decode($result, 1);
+
+        default:
+            throw new RuntimeException("Bad decoder format ($decode)");
+    }
+}


### PR DESCRIPTION
Processor won't get called when there is no logged in user, so in the case of anonymus users (public, unauthenticated) there willb e no `Authorization failed` exception.

Other improvements:
- code refactored to use API calls from `rc-base`
- added unit tests
- changed `hook_civicrm_post` to `hook_civicrm_postCommit`: this action should not be part of a transaction rather called after a succesful one. If it is part of a transaction, then any exception thrown by this API call will be masked as the transaction as a whole will be successful, and it can cause the subsequent SQL queries to fail for no apparent reason.

fixes #1 
closes #2 